### PR TITLE
removed seed_stations_with_city_id method call from bottom of seed file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,6 +34,6 @@ class Seeds
 end
 
 a = Seeds.new
-a.seed_stations_with_city_id
+
 
 puts "station database seeded"


### PR DESCRIPTION
Just didn't want a method called right off the bat